### PR TITLE
Add `allow-all-ingress-from-host` CiliumNetworkPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `allow-all-egress` CiliumClusterwideNetworkPolicy for `cni: cilium`.
+- Add `allow-all-ingress-from-host` CiliumNetworkPolicy (in `kube-system` namespace by default).
 - Add `coredns` NetworkPolicy.
 
 [Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master

--- a/helm/cluster-resources/templates/allow-all-ingress-from-host-cilium-np.yaml
+++ b/helm/cluster-resources/templates/allow-all-ingress-from-host-cilium-np.yaml
@@ -1,0 +1,15 @@
+{{- if eq .Values.cni "cilium" }}
+{{- range $namespace := .Values.cilium.allowAllIngressFromHostIn }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-all-ingress-from-host
+  namespace: {{ $namespace }}
+spec:
+  endpointSelector: {}
+  ingress:
+  - fromEntities:
+    - host
+    - remote-node
+{{- end }}
+{{- end }}

--- a/helm/cluster-resources/values.yaml
+++ b/helm/cluster-resources/values.yaml
@@ -14,3 +14,7 @@ image:
   pullPolicy: IfNotPresent
 
 cni: cilium
+
+cilium:
+  allowAllIngressFromHostIn:
+    - kube-system


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20946

Required so apiserver can scrape targets in `kube-system`. This is due to IP ranges with host IPs not working in cilium.