### PR TITLE
prepare for coredns app adoption

### DIFF
--- a/helm/cluster-resources/templates/coredns-np.yaml
+++ b/helm/cluster-resources/templates/coredns-np.yaml
@@ -1,7 +1,8 @@
+# TODO start: delete after coredns-addoption was done
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: coredns
+  name: kube-dns
   namespace: kube-system
   labels:
     {{- include "labels.common" . | nindent 4 }}
@@ -21,8 +22,13 @@ spec:
     - port: 9153
       protocol: TCP
   podSelector:
-    matchLabels:
-      k8s-app: kube-dns
+    matchExpressions:
+    - key: k8s-app
+      operator: In
+      values: 
+      - kube-dns
+      - coredns
   policyTypes:
   - Egress
   - Ingress
+# TODO end

--- a/helm/cluster-resources/values.schema.json
+++ b/helm/cluster-resources/values.schema.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "cilium": {
+            "type": "object",
+            "properties": {
+                "allowAllIngressFromHostIn": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "cni": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceType": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
To make DNS still work, we have add the additional netpol kube-dns to reduce downtime of DNS within the cluster to a minimum.

To make the adoption and the cleanup of orphaned objects after the adoption as easy as possible we renamed the coredns netpol.

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how cluster-resources can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for cluster-resources installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
